### PR TITLE
Fixing regex to handle additional attributes in anchor tags.

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.cbsnews_com" name="CBSnews.com" version="2.1.0" provider-name="AddonScriptorDE">
+<addon id="plugin.video.cbsnews_com" name="CBSnews.com" version="2.1.1" provider-name="AddonScriptorDE">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
     </requires>

--- a/default.py
+++ b/default.py
@@ -27,8 +27,8 @@ def index():
     xbmcplugin.addSortMethod(pluginhandle, xbmcplugin.SORT_METHOD_LABEL)
     addDir("- "+translation(30002), "", "search", icon)
     content = getUrl(urlMain+"/videos")
-    match = re.compile('<a href="/videos/topics/(.+?)/">(.+?)</a>', re.DOTALL).findall(content)
-    for id, title in match:
+    match = re.compile('<a href="/videos/topics/([^\/]+)/"([^>]+)?>([^<]+)</a>', re.DOTALL).findall(content)
+    for id, ignored_grouping, title in match:
         if id=="48-hours":
             addDir(title, urlMain+"/latest/"+id+"/full-episodes/1", 'listEpisodes', icon)
         elif id=="60-minutes":


### PR DESCRIPTION
Some anchor tags on the video page had "data-vanityrewritten" attributes instead of the closing tag. Updated the regex to handle these.
