### PR TITLE
support high def videos

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.cbsnews_com" name="CBSnews.com" version="2.1.1" provider-name="AddonScriptorDE">
+<addon id="plugin.video.cbsnews_com" name="CBSnews.com" version="2.1.2" provider-name="AddonScriptorDE">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
     </requires>

--- a/default.py
+++ b/default.py
@@ -121,7 +121,9 @@ def playEveningNewsLatest():
 
 def playVideo(url, title="", thumb="DefaultVideo.png"):
     content = getUrl(url)
-    match=re.compile('"mediaHlsURI":"(.+?)"', re.DOTALL).findall(content)
+    match = re.compile('"mediaRtmpMobileHighURI":"(.+?)"',re.DOTALL).findall(content);
+    if not match:
+        match=re.compile('"mediaHlsURI":"(.+?)"', re.DOTALL).findall(content)
     streamUrl = match[0].replace("\\","")
     if thumb!="DefaultVideo.png":
         listitem = xbmcgui.ListItem(path=streamUrl, thumbnailImage=thumb)

--- a/default.py
+++ b/default.py
@@ -121,7 +121,7 @@ def playEveningNewsLatest():
 
 def playVideo(url, title="", thumb="DefaultVideo.png"):
     content = getUrl(url)
-    match = re.compile('"mediaRtmpMobileHighURI":"(.+?)"',re.DOTALL).findall(content);
+    match = re.compile('"mediaRtmpMobileHighURI":"(.+?)"',re.DOTALL).findall(content)
     if not match:
         match=re.compile('"mediaHlsURI":"(.+?)"', re.DOTALL).findall(content)
     streamUrl = match[0].replace("\\","")

--- a/default.py
+++ b/default.py
@@ -121,7 +121,7 @@ def playEveningNewsLatest():
 
 def playVideo(url, title="", thumb="DefaultVideo.png"):
     content = getUrl(url)
-    match = re.compile('"mediaRtmpMobileHighURI":"(.+?)"',re.DOTALL).findall(content)
+    match=re.compile('"mediaRtmpMobileHighURI":"(.+?)"',re.DOTALL).findall(content)
     if not match:
         match=re.compile('"mediaHlsURI":"(.+?)"', re.DOTALL).findall(content)
     streamUrl = match[0].replace("\\","")


### PR DESCRIPTION
CBS plays some videos as audio only, this happens only when you try to play the HLS version (fits ipads/iphones). However if we try to play the high def mp4 it won't happen and leave the HLS as fallback.
